### PR TITLE
add info about which pages get tracked in GA

### DIFF
--- a/contents/articles/screendoor/integrations/analytics.md
+++ b/contents/articles/screendoor/integrations/analytics.md
@@ -5,6 +5,8 @@ app_pages:
   - analytics-show
 ---
 
+### Connecting Screendoor to Google Analytics
+
 Screendoor lets you use your Google Analytics account to track visits to your Screendoor project.
 
 To integrate your Google Analytics account with Screendoor, sign into Google Analytics and select &ldquo;Admin&rdquo; in the top navigation bar. Select the property you want to track in the second column. Under the &ldquo;Tracking Info&rdquo; section, choose &ldquo;Tracking Code.&rdquo;
@@ -18,3 +20,16 @@ Copy the tracking code that appears.
 In Screendoor, click on your avatar in the navigation bar, select &ldquo;Settings&rdquo; from the dropdown, and choose &ldquo;Analytics&rdquo; from the sidebar. Under &ldquo;Google Analytics ID,&rdquo; paste in your tracking code and press &ldquo;Save.&rdquo;
 
 ![Adding your Google Analytics tracking code to Screendoor.](../images/analytics_3.png)
+
+---
+
+## F.A.Q.
+
+### What pages are tracked in Google Analytics?
+
+Screendoor tracks the following pages:
+
+- All projects page
+- Project page
+- Questions page
+- Response confirmation page

--- a/contents/articles/screendoor/integrations/analytics.md
+++ b/contents/articles/screendoor/integrations/analytics.md
@@ -7,7 +7,7 @@ app_pages:
 
 ### Connecting Screendoor to Google Analytics
 
-Screendoor lets you use your Google Analytics account to track visits to your Screendoor project.
+You can connect your Google Analytics account to track visits to your Screendoor project.
 
 To integrate your Google Analytics account with Screendoor, sign into Google Analytics and select &ldquo;Admin&rdquo; in the top navigation bar. Select the property you want to track in the second column. Under the &ldquo;Tracking Info&rdquo; section, choose &ldquo;Tracking Code.&rdquo;
 
@@ -27,9 +27,13 @@ In Screendoor, click on your avatar in the navigation bar, select &ldquo;Setting
 
 ### What pages are tracked in Google Analytics?
 
-Screendoor tracks the following pages:
+Screendoor tracks events on the following pages:
 
-- All projects page
-- Project page
-- Questions page
-- Response confirmation page
+- [`Forms.fm` landing page for all your projects](../projects/branding_your_forms.html)
+- [Project page](../projects/writing_your_project_page.html)
+- [Questions page](../questions/configuring_the_question_and_answer_section.html)
+- [Response confirmation page](../your_form/confirmations.html)
+
+### The status of my Universal Tracking ID is "Tracking not installed." How do I know if the Google Analytics integration is working correctly?
+
+We use a custom script to send data to Google Analytics. If you have recently added the tracking ID to Screendoor, you will need to wait a few hours for the status to update and for the tracked events to appear in your dashboard.


### PR DESCRIPTION
Rewording welcome, but this is (I think) the second time we've gotten this question.

Actually, for that matter, maybe we should add a section about "Why does google say the code isn't working?" (Answer: Because it's a custom code... the events will appear within a few hours.)