### PR TITLE
add notes on manual responses + confirmation emails

### DIFF
--- a/contents/articles/screendoor/responses/importing_responses.md
+++ b/contents/articles/screendoor/responses/importing_responses.md
@@ -95,4 +95,4 @@ When mapping a column to a <span class='label'>Screendoor field</span>, it's imp
 
 ### Will imported respondents receive a confirmation email?
 
-No. If you import responses with an email column and map it to the Respondent email field, these respondents will not receive a [confirmation email](/articles/screendoor/your_form/confirmations.html#customizing-the-confirmation-email).
+No. Even if you import responses with an email column and map it to the Respondent email field, these respondents will not receive a [confirmation email](/articles/screendoor/your_form/confirmations.html#customizing-the-confirmation-email).

--- a/contents/articles/screendoor/responses/importing_responses.md
+++ b/contents/articles/screendoor/responses/importing_responses.md
@@ -95,4 +95,4 @@ When mapping a column to a <span class='label'>Screendoor field</span>, it's imp
 
 ### Will imported respondents receive a confirmation email?
 
-No. When importing responses, any new respondents will not receive a [confirmation email](/articles/screendoor/your_form/confirmations.html#customizing-the-confirmation-email).
+No. If you import responses with an email column and map it to the Respondent email field, these respondents will not receive a [confirmation email](/articles/screendoor/your_form/confirmations.html#customizing-the-confirmation-email).

--- a/contents/articles/screendoor/responses/importing_responses.md
+++ b/contents/articles/screendoor/responses/importing_responses.md
@@ -88,3 +88,11 @@ When mapping a column to a <span class='label'>Screendoor field</span>, it's imp
 | Status | String | `"Open"` | The status must already exist inside of the project. |
 | Labels | Comma-separated | `"A+, Missing info"`| If a label does not exist, it will be created for you. |
 | Assigned to | Comma-separated | `"Barack Obama, HR"` | The list can contain names of individual collaborators, as well as names of [project teams](/articles/screendoor/collaboration/teams.html). |
+
+---
+
+## F.A.Q.
+
+### Will imported respondents receive a confirmation email?
+
+No. When importing responses, any new respondents will not receive a [confirmation email](/articles/screendoor/your_form/confirmations.html#customizing-the-confirmation-email).

--- a/contents/articles/screendoor/responses/manually_add_response.md
+++ b/contents/articles/screendoor/responses/manually_add_response.md
@@ -19,3 +19,9 @@ Fill out the form, and make sure to enter that person's name and email! Press th
 <div class='alert'>
     **Note:** Required fields are _not_ validated when you manually enter a response. If you're transcribing a response that is only partially complete, you can leave as many fields blank as you wish without encountering errors.
 </div>
+
+---
+
+### Will respondents receive a confirmation email when I manually add their response?
+
+No. When manually adding a response, the respondent will not receive a [confirmation email](/articles/screendoor/your_form/confirmations.html#customizing-the-confirmation-email).

--- a/contents/articles/screendoor/responses/manually_add_response.md
+++ b/contents/articles/screendoor/responses/manually_add_response.md
@@ -22,6 +22,8 @@ Fill out the form, and make sure to enter that person's name and email! Press th
 
 ---
 
+## F.A.Q.
+
 ### Will respondents receive a confirmation email when I manually add their response?
 
 No. When manually adding a response, the respondent will not receive a [confirmation email](/articles/screendoor/your_form/confirmations.html#customizing-the-confirmation-email).


### PR DESCRIPTION
did this in GitHub's editor so I haven't previewed in-app.